### PR TITLE
refactor: remove organization key from localize script

### DIFF
--- a/blocks-for-eventbrite.php
+++ b/blocks-for-eventbrite.php
@@ -187,7 +187,6 @@ function render_blocks_for_eventbrite_card($attributes)
         [
             'events' => $transient['events'],
             'attributes' => $transient['attributes'],
-            'organizations'   => $userData
         ]
     );
 


### PR DESCRIPTION
Removes the `organizations` key from the localized script object.